### PR TITLE
fixes direction placeholder (again)

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerUtil.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerUtil.java
@@ -75,7 +75,7 @@ public class PlayerUtil {
   }
 
   public static String getCardinalDirection(Player player) {
-    double rotation = player.getLocation().getYaw() + 180.0F;
+    double rotation = player.getLocation().getYaw() - 180.0F;
     if (rotation < 0.0D) {
       rotation += 360.0D;
     }


### PR DESCRIPTION
So sorry, its me again..
tested the direction placeholder when funnycube make the update like in the cloud and only N, NW, W, SW, S were working cuz it should be `- 180` instead of `+ 180`
it working now (for sure)
i really apologize about that, and for opening alot of pull requests for just this update.
http://aboodyy.net/PAPI-Expansion-Player.jar
