### PR TITLE
Fix for 1.14 server name

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -175,7 +175,7 @@ public class PlayerExpansion extends PlaceholderExpansion implements Configurabl
                 return bool(p.getInventory().firstEmpty() > - 1);
             case "server":
             case "servername":
-            	if(serverVersion >= 14) return "";
+            	if(serverVersion >= 14) return Bukkit.getServer().getName();
             	
                 return Bukkit.getServerName();
             case "displayname":

--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -41,7 +41,9 @@ import static com.extendedclip.papi.expansion.player.PlayerUtil.*;
 public class PlayerExpansion extends PlaceholderExpansion implements Configurable {
 
     private final String VERSION = getClass().getPackage().getImplementationVersion();
-
+    
+    private final int serverVersion = Integer.parseInt(Bukkit.getServer().getClass().getPackage().getName().substring(23).split("_")[1]);
+    
     private String low, medium, high;
 
     @Override
@@ -173,6 +175,8 @@ public class PlayerExpansion extends PlaceholderExpansion implements Configurabl
                 return bool(p.getInventory().firstEmpty() > - 1);
             case "server":
             case "servername":
+            	if(serverVersion >= 14) return "";
+            	
                 return Bukkit.getServerName();
             case "displayname":
                 return p.getDisplayName();


### PR DESCRIPTION
server-name is no longer a value in server.properties with 1.14 and Server#getServerName has been removed. For now returning an empty string to prevent errors with incompatible plugins attempting to parse a player's server name.