### PR TITLE
add/recipes placeholders

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -24,11 +24,7 @@ package com.extendedclip.papi.expansion.player;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.Configurable;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.World;
+import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
@@ -38,15 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.extendedclip.papi.expansion.player.PlayerUtil.format12;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.format24;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.getBiome;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.getCapitalizedBiome;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.getCardinalDirection;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.getEmptySlots;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.getTotalExperience;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.getXZDirection;
-import static com.extendedclip.papi.expansion.player.PlayerUtil.itemInHand;
+import static com.extendedclip.papi.expansion.player.PlayerUtil.*;
 
 public final class PlayerExpansion extends PlaceholderExpansion implements Configurable {
 

--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -140,6 +140,8 @@ public final class PlayerExpansion extends PlaceholderExpansion implements Confi
 
         Player p = player.getPlayer();
 
+        if (p == null) return "";
+
         if (identifier.startsWith("has_permission_")) {
             if (identifier.split("has_permission_").length > 1) {
                 String perm = identifier.split("has_permission_")[1];

--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -173,7 +173,22 @@ public final class PlayerExpansion extends PlaceholderExpansion implements Confi
             return "0";
         }
 
+        if (identifier.startsWith("can_craft_")) {
+            if (identifier.split("can_craft_").length > 1) {
+                String recipeName = identifier.split("can_craft_")[1];
+                try {
+                    return bool(p.hasDiscoveredRecipe(NamespacedKey.minecraft(recipeName)));
+                } catch (IllegalArgumentException e) {
+                    return "invalid recipe"; // could be false instead
+                }
+            }
+            return bool(false);
+        }
+
+
         switch (identifier) {
+            case "recipes":
+                return p.getDiscoveredRecipes().toString(); // sort of ugly (i dont see the use case either)
             case "has_empty_slot":
                 return bool(p.getInventory().firstEmpty() > -1);
             case "empty_slots":


### PR DESCRIPTION
resolves #28 

Questions:
- how should an invalid namespaced key be handled? right now I return `"invalid recipe"`, is that ok?
- for listing recipes, it's really ugly and there's really no use case it seems. maybe it should be removed
- IntelliJ changed around imports. is that ok?
