### PR TITLE
Add new Placeholder block_underneath

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -230,8 +230,7 @@ public final class PlayerExpansion extends PlaceholderExpansion implements Confi
             case "compass_world":
                 return p.getCompassTarget() != null ? p.getCompassTarget().getWorld().getName() : "";
             case "block_underneath":
-                Location loc = Objects.requireNonNull(player.getPlayer()).getLocation().clone().subtract(0, 1, 0);
-                return String.valueOf(loc.getBlock().getType());
+                return String.valueOf(p.getLocation().clone().subtract(0, 1, 0).getBlock().getType());
             case "custom_name":
                 return p.getCustomName() != null ? p.getCustomName() : p.getName();
             case "exp":

--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerExpansion.java
@@ -32,6 +32,7 @@ import org.bukkit.World;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.Location;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -228,6 +229,9 @@ public final class PlayerExpansion extends PlaceholderExpansion implements Confi
                 return p.getCompassTarget() != null ? String.valueOf(p.getCompassTarget().getBlockZ()) : "";
             case "compass_world":
                 return p.getCompassTarget() != null ? p.getCompassTarget().getWorld().getName() : "";
+            case "block_underneath":
+                Location loc = Objects.requireNonNull(player.getPlayer()).getLocation().clone().subtract(0, 1, 0);
+                return String.valueOf(loc.getBlock().getType());
             case "custom_name":
                 return p.getCustomName() != null ? p.getCustomName() : p.getName();
             case "exp":


### PR DESCRIPTION
block_underneath will return the block the player that is directly underneath the player. May add one in later update that adds an extra placeholder that will not return blocks like lava, air. water, etc.