### PR TITLE
feat: use `Player#getPing` for 1.17+

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/player/PlayerUtil.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/PlayerUtil.java
@@ -1,5 +1,7 @@
 package com.extendedclip.papi.expansion.player;
 
+import me.clip.placeholderapi.PlaceholderAPI;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -14,6 +16,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.logging.Level;
 
 /*
  *
@@ -54,6 +57,12 @@ public final class PlayerUtil {
 
         @Override
         public Integer apply(final Player player) {
+            // 1.17 added Player#getPing, and we can use that directly
+            if (VersionHelper.IS_1_17_OR_NEWER) {
+                return player.getPing();
+            }
+
+            // For versions before 1.17 we need to use reflection
             if (ping == null) {
                 try {
                     cacheReflection(player);
@@ -65,7 +74,9 @@ public final class PlayerUtil {
             try {
                 return ping.getInt(getHandle.invoke(player));
             } catch (final IllegalAccessException | InvocationTargetException ex) {
-                ex.printStackTrace();
+                PlaceholderAPIPlugin.getInstance()
+                                .getLogger()
+                                .log(Level.SEVERE, "Could not get the ping of " + player.getName() + ", using -1 as fallback value", ex);
             }
             return -1;
         }
@@ -76,17 +87,7 @@ public final class PlayerUtil {
             getHandle.setAccessible(true);
 
             final Object entityPlayer = getHandle.invoke(player);
-
-            String pingFieldName;
-            if (VersionHelper.IS_1_20_OR_NEWER) {
-                pingFieldName = "f";
-            } else if (VersionHelper.IS_1_17_OR_NEWER) {
-                pingFieldName = "e";
-            } else {
-                pingFieldName = "ping";
-            }
-
-            ping = entityPlayer.getClass().getDeclaredField(pingFieldName);
+            ping = entityPlayer.getClass().getDeclaredField("ping");
             ping.setAccessible(true);
         }
     };
@@ -110,7 +111,9 @@ public final class PlayerUtil {
                 final Object entityPlayer = getHandle.invoke(player);
                 return (String) locale.get(entityPlayer);
             } catch (final IllegalAccessException | InvocationTargetException ex) {
-                ex.printStackTrace();
+                PlaceholderAPIPlugin.getInstance()
+                        .getLogger()
+                        .log(Level.SEVERE, "Could not get the locale of " + player.getName() + ", using 'en_US' as fallback value", ex);
             }
             return "en_US";
         }

--- a/src/main/java/com/extendedclip/papi/expansion/player/VersionHelper.java
+++ b/src/main/java/com/extendedclip/papi/expansion/player/VersionHelper.java
@@ -2,6 +2,8 @@ package com.extendedclip.papi.expansion.player;
 
 import com.google.common.primitives.Ints;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Damageable;
+import org.bukkit.entity.Player;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,15 +16,14 @@ public final class VersionHelper {
     private static final int VERSION = getCurrentVersion();
 
     /**
-     * <a href="https://docs.docdex.helpch.at/1.15/org/bukkit/entity/Damageable.html#getAbsorptionAmount--">
-     * Damageable#getAbsorptionAmount
-     * </a>
+     * @see Damageable#getAbsorptionAmount()
      */
     public static final boolean HAS_ABSORPTION_METHODS = VERSION >= 1_15_0;
 
+    /**
+     * @see Player#getPing()
+     */
     public static final boolean IS_1_17_OR_NEWER = VERSION >= 1_17_0;
-
-    public static final boolean IS_1_20_OR_NEWER = VERSION >= 1_20_0;
 
     private VersionHelper() { }
 


### PR DESCRIPTION
This was suggested by @tanguygab on [discord](https://discord.com/channels/164280494874165248/573429521554866178/1119703786219376731):
> Hey, just realized that 1.17 added a getPing method in the Player class, it could be better to use that in the Player Expansion in case another version changes the ping field, so you use reflection as usual for 1.16- (the field is just "ping" I think) and on 1.17+ you use the method
It would prevent the placeholder to break on new MC versions, again